### PR TITLE
chore: add GitHub Actions workflow to notify PR via Mattermost

### DIFF
--- a/.github/workflows/pr-mattermost.yml
+++ b/.github/workflows/pr-mattermost.yml
@@ -1,0 +1,18 @@
+name: PR Notification to Mattermost
+
+on:
+  pull_request:
+    types: [opened, reopened]  # PR 생성 또는 다시 열릴 때 작동
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send PR to Mattermost
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+          -d '{
+                "text": ":bell: Pull Request 생성됨!\n> 제목: '${{ github.event.pull_request.title }}'\n> 작성자: '${{ github.actor }}'\n> 링크: '${{ github.event.pull_request.html_url }}'"
+              }' \
+          ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- PR이 생성되거나 다시 열릴 때 Mattermost 채널로 알림이 전송되는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->