### PR TITLE
[chore] 추 기능을 위한 테이블 생성 및 수정

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,5 +1,6 @@
 USE ssafytrip;
 
+/*
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nickname VARCHAR(50) NOT NULL,
@@ -14,14 +15,68 @@ CREATE TABLE IF NOT EXISTS users (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
+*/
 
+/* 유저 테이블 수정*/
+CREATE TABLE `users` (
+   `id` int NOT NULL AUTO_INCREMENT,
+   `nickname` varchar(50) NOT NULL,
+   `name` varchar(50) NOT NULL,
+   `email` varchar(100) NOT NULL,
+   `password` varchar(255) NOT NULL,
+   `profile_image` varchar(255) DEFAULT NULL,
+   `role` enum('USER','ADMIN') DEFAULT 'USER',
+   `bio` text,
+   `gender` enum('MALE','FEMALE') DEFAULT NULL,
+   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+   `age` int DEFAULT NULL,
+   `city_nature_prefer` int DEFAULT NULL COMMENT '도시 자연 선호도',
+   `residence_sido_code` int DEFAULT NULL COMMENT '거주지 시도코드',
+   `residence_gugun_code` int DEFAULT NULL COMMENT '거주지 구군코드',
+   PRIMARY KEY (`id`),
+   UNIQUE KEY `email` (`email`),
+   KEY `users_sido_code_fk` (`residence_sido_code`),
+   KEY `users_gugun_code_fk` (`residence_gugun_code`),
+   CONSTRAINT `users_gugun_code_fk` FOREIGN KEY (`residence_gugun_code`) REFERENCES `guguns` (`gugun_code`),
+   CONSTRAINT `users_sido_code_fk` FOREIGN KEY (`residence_sido_code`) REFERENCES `sidos` (`sido_code`)
+ ) 
+ 
 
+/*리뷰 테이블*/
+CREATE TABLE `reviews` (
+   `review_id` int NOT NULL AUTO_INCREMENT,
+   `user_id` int NOT NULL,
+   `rating` float DEFAULT NULL,
+   `review_like` int DEFAULT '0',
+   `content` varchar(1000) DEFAULT NULL,
+   `title` varchar(255) DEFAULT NULL,
+   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+   `modified_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+   `no` int DEFAULT NULL,
+   `motive_code` int DEFAULT NULL COMMENT '동기 코드',
+   `com_num` int DEFAULT NULL COMMENT '여행 동반자 수',
+   PRIMARY KEY (`review_id`),
+   KEY `user_id` (`user_id`),
+   KEY `no` (`no`),
+   KEY `fk_reviews_motive_code` (`motive_code`),
+   CONSTRAINT `fk_reviews_motive_code` FOREIGN KEY (`motive_code`) REFERENCES `motive` (`motive_code`),
+   CONSTRAINT `reviews_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+   CONSTRAINT `reviews_ibfk_2` FOREIGN KEY (`no`) REFERENCES `spots` (`no`)
+ )
 
-CREATE TABLE IF NOT EXISTS spot_like (
-    spot_id INT,
-    user_id INT,
-    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (spot_id, user_id),
-+    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (spot_id) REFERENCES ssafytrip.attractions(no)
+/* 동기 테이블 */
+CREATE TABLE `motive` (
+    `motive_id` INT NOT NULL AUTO_INCREMENT COMMENT '동기 id (기본키)',
+    `motive_code` INT NOT NULL COMMENT '동기 코드',
+    `motive_name` VARCHAR(255) NOT NULL COMMENT '동기 이름',
+    PRIMARY KEY (`motive_id`)
 );
+
+
+
+
+
+ 
+ 
+ 


### PR DESCRIPTION
✅ users 테이블 생성
회원 정보를 저장하는 users 테이블 생성

sidos, guguns 테이블의 시도코드/구군코드를 외래키로 연결

role, gender는 ENUM 타입으로 지정

생성일/수정일 자동 설정

✅ motive 테이블 생성
여행 동기를 관리하는 motive 테이블 생성

motive_id는 기본키, motive_code는 고유 코드

여행 동기명을 저장하는 motive_name 포함

✅ reviews 테이블 수정
motive_code 컬럼 추가 → motive.motive_code를 외래키로 참조

com_num 컬럼 추가 → 여행 동반자 수(INT)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보에 도시/자연 선호도, 거주 지역 코드 등 추가 항목이 포함되었습니다.
  - 리뷰 작성 및 관리가 가능한 리뷰 기능이 도입되었습니다.
  - 다양한 동기(모티브)를 선택할 수 있는 동기 테이블이 추가되었습니다.

- **변경 사항**
  - 이메일 중복 등록이 불가능하도록 고유 인덱스가 적용되었습니다.
  - 나이와 프로필 이미지 항목의 기본값이 변경되었습니다.

- **제거**
  - 장소 좋아요 기능이 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->