### PR TITLE
[chore] 관광지 조회를 위한 spot dto와 api 수정

### DIFF
--- a/src/main/java/com/ssafy/live/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/ssafy/live/domain/review/service/ReviewServiceImpl.java
@@ -1,6 +1,6 @@
 package com.ssafy.live.domain.review.service;
 
-import java.util.List;
+import java.util.List; 
 import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
@@ -10,11 +10,9 @@ import com.ssafy.live.domain.review.dao.ReviewDao;
 import com.ssafy.live.domain.review.dto.ReviewRequestDto;
 import com.ssafy.live.domain.review.dto.ReviewResponseDto;
 import com.ssafy.live.domain.spot.dao.SpotDao;
-import com.ssafy.live.domain.spot.dto.SpotDto;
-import com.ssafy.live.domain.spot.service.SpotService; 
+import com.ssafy.live.domain.spot.dto.BasicSpotResponseDto;
 import com.ssafy.live.domain.user.dao.UserDao;
 import com.ssafy.live.domain.user.dto.UserDto;
-import com.ssafy.live.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,7 +35,7 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         // 관광지 존재 확인
-        SpotDto spot = spotDao.selectSpotByNo(reviewRequestDto.getNo());
+        BasicSpotResponseDto spot = spotDao.selectBasicSpotByNo(reviewRequestDto.getNo());
         if (spot == null) {
             throw new NoSuchElementException("존재하지 않는 관광지입니다.");
         }
@@ -156,7 +154,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Override
     public List<ReviewResponseDto> getReviewsBySpotNo(int spotNo) {
         // 관광지 존재 확인
-        SpotDto spot = spotDao.selectSpotByNo(spotNo);
+        BasicSpotResponseDto spot = spotDao.selectBasicSpotByNo(spotNo);
         if (spot == null) {
             throw new NoSuchElementException("존재하지 않는 관광지입니다.");
         }

--- a/src/main/java/com/ssafy/live/domain/spot/controller/SpotController.java
+++ b/src/main/java/com/ssafy/live/domain/spot/controller/SpotController.java
@@ -1,9 +1,6 @@
 package com.ssafy.live.domain.spot.controller;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,61 +12,68 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ssafy.live.domain.spot.dto.SpotDto;
+import com.ssafy.live.domain.spot.dto.BasicSpotResponseDto;
+import com.ssafy.live.domain.spot.dto.DetailSpotResponseDto;
 import com.ssafy.live.domain.spot.service.SpotService;
-
 import lombok.RequiredArgsConstructor;
-
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/spots")
 public class SpotController {
-	
-	private final SpotService spotService;
-	
-	
-    // 모든 관광지 조회
-    @GetMapping
-    public ResponseEntity<List<SpotDto>> getAllSpots() {
-        List<SpotDto> spots = spotService.getAllSpots();
-        return new ResponseEntity<>(spots, HttpStatus.OK);
-    }
     
-
-    // ID로 특정 관광지 조회
+    private final SpotService spotService;
+    
+    /**
+     * 특정 관광지의 기본 정보 조회 (평균평점, 리뷰수 포함)
+     * @param no 관광지 번호
+     * @return 기본 관광지 정보
+     */
     @GetMapping("/{no}")
-    public ResponseEntity<SpotDto> getSpotByNo(@PathVariable int no) {
-        SpotDto spot = spotService.getSpotByNo(no);
+    public ResponseEntity<BasicSpotResponseDto> getBasicSpotByNo(@PathVariable int no) {
+        BasicSpotResponseDto spot = spotService.getBasicSpotByNo(no);
         return new ResponseEntity<>(spot, HttpStatus.OK);
     }
     
-    // 관광지 삭제
+    /**
+     * 특정 관광지의 상세 정보 조회 (연령대별 평점, 인기 동행타입, 인기 모티브 포함)
+     * @param no 관광지 번호
+     * @return 상세 관광지 정보
+     */
+    @GetMapping("/{no}/detail")
+    public ResponseEntity<DetailSpotResponseDto> getDetailSpotByNo(@PathVariable int no) {
+        DetailSpotResponseDto spot = spotService.getDetailSpotByNo(no);
+        return new ResponseEntity<>(spot, HttpStatus.OK);
+    }
+    
+    /**
+     * 관광지 삭제
+     * @param no 관광지 번호
+     */
     @DeleteMapping("/{no}")
     public ResponseEntity<Void> deleteSpot(@PathVariable int no) {
         spotService.deleteSpot(no);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
     
-    // 새 관광지 생성
-    @PostMapping
-    public ResponseEntity<SpotDto> createSpot(@RequestBody SpotDto spotDto) {
-        SpotDto createdSpot = spotService.insertSpot(spotDto);
-        return new ResponseEntity<>(createdSpot, HttpStatus.CREATED);
+    /**
+     * 좌표 경계 내의 관광지 기본 정보 조회 (평균평점, 리뷰수 포함)
+     * @param swLat 남서쪽 위도
+     * @param swLng 남서쪽 경도  
+     * @param neLat 북동쪽 위도
+     * @param neLng 북동쪽 경도
+     * @param type 관광지 타입 (선택사항)
+     * @return 경계 내 관광지 기본 정보 리스트
+     */
+    @GetMapping("/in-boundary")
+    public ResponseEntity<List<BasicSpotResponseDto>> getSpotsInBoundary(
+            @RequestParam double swLat,
+            @RequestParam double swLng,
+            @RequestParam double neLat,
+            @RequestParam double neLng,
+            @RequestParam(required = false) Integer type  // content_type_id
+    ) {
+        List<BasicSpotResponseDto> spots = spotService.getBasicSpotsInBoundary(swLat, swLng, neLat, neLng, type);
+        return ResponseEntity.ok(spots);
     }
-    
-    // 좌표 주변의 관광지 가져오기
-	@GetMapping("/in-boundary")
-	public ResponseEntity<List<SpotDto>> getSpotsInBoundary(
-	        @RequestParam double swLat,
-	        @RequestParam double swLng,
-	        @RequestParam double neLat,
-	        @RequestParam double neLng,
-	        @RequestParam(required = false) Integer type  // content_type_id
-	) {
-	    List<SpotDto> spots = spotService.getSpotsInBoundary(swLat, swLng, neLat, neLng, type);
-	    return ResponseEntity.ok(spots);
-	}
-	
-	
 }

--- a/src/main/java/com/ssafy/live/domain/spot/dao/SpotDao.java
+++ b/src/main/java/com/ssafy/live/domain/spot/dao/SpotDao.java
@@ -1,24 +1,48 @@
 package com.ssafy.live.domain.spot.dao;
 
-import java.util.Date;
 import java.util.List;
-
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
-import com.ssafy.live.domain.spot.dto.SpotDto;
+import com.ssafy.live.domain.spot.dto.AgeRatingDto;
+import com.ssafy.live.domain.spot.dto.BasicSpotResponseDto;
 
 @Mapper
-
 public interface SpotDao {
-	
-    List<SpotDto> selectAllSpots();
     
-    SpotDto selectSpotByNo(int no);
-
-    int insertSpot(SpotDto spotDto);
-
+    /**
+     * 특정 관광지의 기본 정보 조회 (평균평점, 리뷰수 포함)
+     */
+    BasicSpotResponseDto selectBasicSpotByNo(int no);
+    
+    /**
+     * 특정 관광지의 연령대별 평점 조회
+     */
+    AgeRatingDto selectAgeRatingsByNo(int no);
+    
+    /**
+     * 특정 관광지에서 가장 인기있는 동행타입 조회
+     */
+    String selectMostPopularAccompanyTypeByNo(int no);
+    
+    /**
+     * 특정 관광지에서 가장 인기있는 모티브 조회
+     */
+    String selectMostPopularMotiveByNo(int no);
+    
+    /**
+     * 관광지 삭제
+     */
     int deleteSpot(int no);
     
-	List<SpotDto> findInBounds(double swLat, double swLng, double neLat, double neLng, Integer type);
-
+    /**
+     * 경계 내 관광지 기본 정보 조회 (평균평점, 리뷰수 포함)
+     */
+    List<BasicSpotResponseDto> selectBasicSpotsInBoundary(
+        @Param("swLat") double swLat, 
+        @Param("swLng") double swLng, 
+        @Param("neLat") double neLat, 
+        @Param("neLng") double neLng, 
+        @Param("type") Integer type
+    );
 }

--- a/src/main/java/com/ssafy/live/domain/spot/dto/AgeRatingDto.java
+++ b/src/main/java/com/ssafy/live/domain/spot/dto/AgeRatingDto.java
@@ -1,0 +1,63 @@
+package com.ssafy.live.domain.spot.dto;
+
+import lombok.Data;
+//연령대별 평점 DTO
+public class AgeRatingDto {
+ private double twenties;  // 20대
+ private double thirties;  // 30대
+ private double forties;   // 40대
+ private double fifties;   // 50대
+ private double sixties;   // 60대 이상
+ 
+ public AgeRatingDto() {}
+ 
+ public AgeRatingDto(double twenties, double thirties, double forties, 
+                    double fifties, double sixties) {
+     this.twenties = twenties;
+     this.thirties = thirties;
+     this.forties = forties;
+     this.fifties = fifties;
+     this.sixties = sixties;
+ }
+ 
+ // Getters and Setters
+ public double getTwenties() {
+     return twenties;
+ }
+ 
+ public void setTwenties(double twenties) {
+     this.twenties = twenties;
+ }
+ 
+ public double getThirties() {
+     return thirties;
+ }
+ 
+ public void setThirties(double thirties) {
+     this.thirties = thirties;
+ }
+ 
+ public double getForties() {
+     return forties;
+ }
+ 
+ public void setForties(double forties) {
+     this.forties = forties;
+ }
+ 
+ public double getFifties() {
+     return fifties;
+ }
+ 
+ public void setFifties(double fifties) {
+     this.fifties = fifties;
+ }
+ 
+ public double getSixties() {
+     return sixties;
+ }
+ 
+ public void setSixties(double sixties) {
+     this.sixties = sixties;
+ }
+}

--- a/src/main/java/com/ssafy/live/domain/spot/dto/BasicSpotResponseDto.java
+++ b/src/main/java/com/ssafy/live/domain/spot/dto/BasicSpotResponseDto.java
@@ -1,0 +1,89 @@
+package com.ssafy.live.domain.spot.dto;
+
+
+
+import java.math.BigDecimal; 
+
+import lombok.Data;
+
+//기본 장소 응답 DTO
+public class BasicSpotResponseDto {
+ private int no;
+ private String title;
+ private int contentTypeId;
+ private double latitude;
+ private double longitude;
+ private double averageRating;
+ private int reviewCount;
+ 
+ public BasicSpotResponseDto() {}
+ 
+ public BasicSpotResponseDto(int no, String title, int contentTypeId, 
+                            double latitude, double longitude, 
+                            double averageRating, int reviewCount) {
+     this.no = no;
+     this.title = title;
+     this.contentTypeId = contentTypeId;
+     this.latitude = latitude;
+     this.longitude = longitude;
+     this.averageRating = averageRating;
+     this.reviewCount = reviewCount;
+ }
+ 
+ // Getters and Setters
+ public int getNo() {
+     return no;
+ }
+ 
+ public void setNo(int no) {
+     this.no = no;
+ }
+ 
+ public String getTitle() {
+     return title;
+ }
+ 
+ public void setTitle(String title) {
+     this.title = title;
+ }
+ 
+ public int getContentTypeId() {
+     return contentTypeId;
+ }
+ 
+ public void setContentTypeId(int contentTypeId) {
+     this.contentTypeId = contentTypeId;
+ }
+ 
+ public double getLatitude() {
+     return latitude;
+ }
+ 
+ public void setLatitude(double latitude) {
+     this.latitude = latitude;
+ }
+ 
+ public double getLongitude() {
+     return longitude;
+ }
+ 
+ public void setLongitude(double longitude) {
+     this.longitude = longitude;
+ }
+ 
+ public double getAverageRating() {
+     return averageRating;
+ }
+ 
+ public void setAverageRating(double averageRating) {
+     this.averageRating = averageRating;
+ }
+ 
+ public int getReviewCount() {
+     return reviewCount;
+ }
+ 
+ public void setReviewCount(int reviewCount) {
+     this.reviewCount = reviewCount;
+ }
+}

--- a/src/main/java/com/ssafy/live/domain/spot/dto/DetailSpotResponseDto.java
+++ b/src/main/java/com/ssafy/live/domain/spot/dto/DetailSpotResponseDto.java
@@ -1,0 +1,49 @@
+package com.ssafy.live.domain.spot.dto;
+
+import lombok.Data;
+
+//상세 장소 응답 DTO
+public class DetailSpotResponseDto extends BasicSpotResponseDto {
+ private AgeRatingDto ageRatings;
+ private String mostPopularAccompanyType;
+ private String mostPopularMotive;
+ 
+ public DetailSpotResponseDto() {}
+ 
+ public DetailSpotResponseDto(int no, String title, int contentTypeId, 
+                             double latitude, double longitude, 
+                             double averageRating, int reviewCount,
+                             AgeRatingDto ageRatings, 
+                             String mostPopularAccompanyType, 
+                             String mostPopularMotive) {
+     super(no, title, contentTypeId, latitude, longitude, averageRating, reviewCount);
+     this.ageRatings = ageRatings;
+     this.mostPopularAccompanyType = mostPopularAccompanyType;
+     this.mostPopularMotive = mostPopularMotive;
+ }
+ 
+ // Getters and Setters
+ public AgeRatingDto getAgeRatings() {
+     return ageRatings;
+ }
+ 
+ public void setAgeRatings(AgeRatingDto ageRatings) {
+     this.ageRatings = ageRatings;
+ }
+ 
+ public String getMostPopularAccompanyType() {
+     return mostPopularAccompanyType;
+ }
+ 
+ public void setMostPopularAccompanyType(String mostPopularAccompanyType) {
+     this.mostPopularAccompanyType = mostPopularAccompanyType;
+ }
+ 
+ public String getMostPopularMotive() {
+     return mostPopularMotive;
+ }
+ 
+ public void setMostPopularMotive(String mostPopularMotive) {
+     this.mostPopularMotive = mostPopularMotive;
+ }
+}

--- a/src/main/java/com/ssafy/live/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/live/domain/spot/service/SpotService.java
@@ -1,23 +1,40 @@
 package com.ssafy.live.domain.spot.service;
 
-import java.math.BigDecimal;
 import java.util.List;
 
-import com.ssafy.live.domain.spot.dto.SpotDto;
+import com.ssafy.live.domain.spot.dto.BasicSpotResponseDto;
+import com.ssafy.live.domain.spot.dto.DetailSpotResponseDto;
 
 public interface SpotService {
-    // 모든 관광지 조회
-    List<SpotDto> getAllSpots();
     
-    // no로 특정 관광지 조회
-    SpotDto getSpotByNo(int no);
+    /**
+     * 특정 관광지의 기본 정보 조회 (평균평점, 리뷰수 포함)
+     * @param no 관광지 번호
+     * @return 기본 관광지 정보
+     */
+    BasicSpotResponseDto getBasicSpotByNo(int no);
     
-    // 관광지 삭제
+    /**
+     * 특정 관광지의 상세 정보 조회 (연령대별 평점, 인기 동행타입, 인기 모티브 포함)
+     * @param no 관광지 번호
+     * @return 상세 관광지 정보
+     */
+    DetailSpotResponseDto getDetailSpotByNo(int no);
+    
+    /**
+     * 관광지 삭제
+     * @param no 관광지 번호
+     */
     void deleteSpot(int no);
     
-    // 새 관광지 생성
-    SpotDto insertSpot(SpotDto spotDto);
-    
-    List<SpotDto> getSpotsInBoundary(double swLat, double swLng, double neLat, double neLng, Integer type);
-
+    /**
+     * 좌표 경계 내의 관광지 기본 정보 조회 (평균평점, 리뷰수 포함)
+     * @param swLat 남서쪽 위도
+     * @param swLng 남서쪽 경도
+     * @param neLat 북동쪽 위도
+     * @param neLng 북동쪽 경도
+     * @param type 관광지 타입 (선택사항)
+     * @return 경계 내 관광지 기본 정보 리스트
+     */
+    List<BasicSpotResponseDto> getBasicSpotsInBoundary(double swLat, double swLng, double neLat, double neLng, Integer type);
 }

--- a/src/main/resources/domain/spot/mapper/Spot.xml
+++ b/src/main/resources/domain/spot/mapper/Spot.xml
@@ -5,125 +5,106 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 <mapper namespace="com.ssafy.live.domain.spot.dao.SpotDao">
 
-    <resultMap id="SpotMap" type="com.ssafy.live.domain.spot.dto.SpotDto">
-        <!-- 기본 키 필드 매핑 (프라이머리 키) -->
+    <!-- BasicSpotResponseDto ResultMap -->
+    <resultMap id="BasicSpotMap" type="com.ssafy.live.domain.spot.dto.BasicSpotResponseDto">
         <id property="no" column="no" />
-        
-        <!-- 일반 필드 매핑 (property: 자바 객체 필드명, column: DB 컬럼명) -->
         <result property="title" column="title" />
         <result property="contentTypeId" column="content_type_id" />
-        <result property="areaCode" column="area_code" />
-        <result property="siGunGuCode" column="si_gun_gu_code" />
-        <result property="firstImage1" column="first_image1" />
-        <result property="firstImage2" column="first_image2" />
         <result property="latitude" column="latitude" />
         <result property="longitude" column="longitude" />
-        <result property="addr" column="addr" />
-        <result property="homepage" column="homepage" />
-        <result property="overview" column="overview" />
+        <result property="averageRating" column="average_rating" />
+        <result property="reviewCount" column="review_count" />
     </resultMap>
 
-    <!-- 모든 관광지 조회 -->
-    <select id="selectAllSpots" resultMap="SpotMap">
-        SELECT
-            no,
-            title,
-            content_type_id,
-            area_code,
-            si_gun_gu_code,
-            first_image1,
-            first_image2,
-            latitude,
-            longitude,
-            addr,
-            homepage,
-            overview
-        FROM
-            trippick.spots
-        ORDER BY
-            no
-    </select>
-    
-    <!-- 특정 관광지 조회 (no 기준) -->
-    <select id="selectSpotByNo" parameterType="int" resultMap="SpotMap">
-        SELECT
-            no,
-            title,
-            content_type_id,
-            area_code,
-            si_gun_gu_code,
-            first_image1,
-            first_image2,
-            latitude,
-            longitude,
-            addr,
-            homepage,
-            overview
-        FROM
-            trippick.spots
-        WHERE
-            no = #{no}
+    <!-- AgeRatingDto ResultMap -->
+    <resultMap id="AgeRatingMap" type="com.ssafy.live.domain.spot.dto.AgeRatingDto">
+        <result property="twenties" column="twenties" />
+        <result property="thirties" column="thirties" />
+        <result property="forties" column="forties" />
+        <result property="fifties" column="fifties" />
+        <result property="sixties" column="sixties" />
+    </resultMap>
+
+    <!-- 특정 관광지의 기본 정보 조회 (평균평점, 리뷰수 포함) -->
+    <select id="selectBasicSpotByNo" parameterType="int" resultMap="BasicSpotMap">
+        SELECT 
+            s.no,
+            s.title,
+            s.content_type_id,
+            s.latitude,
+            s.longitude,
+            COALESCE(AVG(r.rating), 0) as average_rating,
+            COUNT(r.review_id) as review_count
+        FROM spots s
+        LEFT JOIN reviews r ON s.no = r.no
+        WHERE s.no = #{no}
+        GROUP BY s.no, s.title, s.content_type_id, s.latitude, s.longitude
     </select>
 
-    <!-- 관광지 등록 -->
-    <insert id="insertSpot" parameterType="com.ssafy.live.domain.spot.dto.SpotDto" useGeneratedKeys="true" keyProperty="no">
-        INSERT INTO trippick.spots (
-            title,
-            content_type_id,
-            area_code,
-            si_gun_gu_code,
-            first_image1,
-            first_image2,
-            latitude,
-            longitude,
-            addr,
-            homepage,
-            overview
-        ) VALUES (
-            #{title},
-            #{contentTypeId},
-            #{areaCode},
-            #{siGunGuCode},
-            #{firstImage1},
-            #{firstImage2},
-            #{latitude},
-            #{longitude},
-            #{addr},
-            #{homepage},
-            #{overview}
-        )
-    </insert>
-    
+    <!-- 특정 관광지의 연령대별 평점 조회 -->
+    <select id="selectAgeRatingsByNo" parameterType="int" resultMap="AgeRatingMap">
+        SELECT 
+            COALESCE(AVG(CASE WHEN u.age BETWEEN 20 AND 29 THEN r.rating END), 0) as twenties,
+            COALESCE(AVG(CASE WHEN u.age BETWEEN 30 AND 39 THEN r.rating END), 0) as thirties,
+            COALESCE(AVG(CASE WHEN u.age BETWEEN 40 AND 49 THEN r.rating END), 0) as forties,
+            COALESCE(AVG(CASE WHEN u.age BETWEEN 50 AND 59 THEN r.rating END), 0) as fifties,
+            COALESCE(AVG(CASE WHEN u.age >= 60 THEN r.rating END), 0) as sixties
+        FROM reviews r
+        JOIN users u ON r.user_id = u.id
+        WHERE r.no = #{no}
+    </select>
+
+    <!-- 특정 관광지에서 가장 인기있는 동행타입 조회 -->
+    <select id="selectMostPopularAccompanyTypeByNo" parameterType="int" resultType="string">
+        SELECT a.accompany_label
+        FROM reviews r
+        JOIN users u ON r.user_id = u.id
+        JOIN accompany a ON u.accompany_code = a.accompany_code
+        WHERE r.no = #{no}
+        GROUP BY a.accompany_code, a.accompany_label
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+    </select>
+
+    <!-- 특정 관광지에서 가장 인기있는 모티브 조회 -->
+    <select id="selectMostPopularMotiveByNo" parameterType="int" resultType="string">
+        SELECT m.motive_name
+        FROM reviews r
+        JOIN users u ON r.user_id = u.id
+        JOIN user_tralve_motive utm ON u.id = utm.user_id
+        JOIN motive m ON utm.motive_code = m.motive_code
+        WHERE r.no = #{no}
+        GROUP BY m.motive_code, m.motive_name
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+    </select>
+
     <!-- 관광지 삭제 -->
     <delete id="deleteSpot" parameterType="int">
-        DELETE FROM trippick.spots
+        DELETE FROM spots
         WHERE no = #{no}
     </delete>
-    
-    <!-- 경계 내 관광지 검색 -->
-    <select id="findInBounds" resultMap="SpotMap" parameterType="map">
-        SELECT
-            no,
-            title,
-            content_type_id,
-            area_code,
-            si_gun_gu_code,
-            first_image1,
-            first_image2,
-            latitude,
-            longitude,
-            addr,
-            homepage,
-            overview
-        FROM
-            trippick.spots
-        WHERE
-            latitude BETWEEN #{swLat} AND #{neLat}
-            AND longitude BETWEEN #{swLng} AND #{neLng}
-            <if test="type != null">
-                AND content_type_id = #{type}
-            </if>
-        ORDER BY no
+
+    <!-- 경계 내 관광지 기본 정보 조회 (평균평점, 리뷰수 포함) -->
+    <select id="selectBasicSpotsInBoundary" resultMap="BasicSpotMap" parameterType="map">
+        SELECT 
+            s.no,
+            s.title,
+            s.content_type_id,
+            s.latitude,
+            s.longitude,
+            COALESCE(AVG(r.rating), 0) as average_rating,
+            COUNT(r.review_id) as review_count
+        FROM spots s
+        LEFT JOIN reviews r ON s.no = r.no
+        WHERE s.latitude BETWEEN #{swLat} AND #{neLat}
+        AND s.longitude BETWEEN #{swLng} AND #{neLng}
+        <if test="type != null">
+            AND s.content_type_id = #{type}
+        </if>
+        GROUP BY s.no, s.title, s.content_type_id, s.latitude, s.longitude
+        ORDER BY s.no
         LIMIT 300
     </select>
+
 </mapper>

--- a/src/test/java/com/ssafy/live/domain/spot/dao/SpotDaoTest.java
+++ b/src/test/java/com/ssafy/live/domain/spot/dao/SpotDaoTest.java
@@ -1,119 +1,172 @@
 package com.ssafy.live.domain.spot.dao;
 
 import com.ssafy.live.domain.spot.dao.SpotDao;
-import com.ssafy.live.domain.spot.dto.SpotDto;
+import com.ssafy.live.domain.spot.dto.AgeRatingDto;
+import com.ssafy.live.domain.spot.dto.BasicSpotResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Date;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
 public class SpotDaoTest {
+    
     @Autowired
     private SpotDao spotDao;
     
-    /*
     @Test
-    @DisplayName("모든 관광지 조회 테스트")
-    void selectAllSpots() {
-        // when
-        List<SpotDto> spots = spotDao.selectAllSpots();
-        
-        // then
-        assertThat(spots).isNotNull();
-        // 데이터가 있다고 가정
-        assertThat(spots).isNotEmpty();
-    }*/
-    
-    @Test
-    @DisplayName("관광지 번호로 조회 테스트")
-    void selectSpotByNo() {
+    @DisplayName("관광지 기본 정보 조회 테스트")
+    void selectBasicSpotByNo() {
         // given
         int existingNo = 1; // 데이터베이스에 존재하는 번호라고 가정
         
         // when
-        SpotDto spot = spotDao.selectSpotByNo(existingNo);
+        BasicSpotResponseDto spot = spotDao.selectBasicSpotByNo(existingNo);
         
         // then
         assertThat(spot).isNotNull();
         assertThat(spot.getNo()).isEqualTo(existingNo);
+        assertThat(spot.getTitle()).isNotNull();
+        assertThat(spot.getContentTypeId()).isNotNull();
+        assertThat(spot.getLatitude()).isNotNull();
+        assertThat(spot.getLongitude()).isNotNull();
+        assertThat(spot.getAverageRating()).isNotNull();
+        assertThat(spot.getReviewCount()).isNotNull();
+        
+        // 평균평점은 0 이상 5 이하여야 함
+        assertThat(spot.getAverageRating()).isBetween(0.0, 5.0);
+        // 리뷰수는 0 이상이어야 함
+        assertThat(spot.getReviewCount()).isGreaterThanOrEqualTo(0);
     }
     
     @Test
-    @DisplayName("존재하지 않는 관광지 번호로 조회 테스트")
-    void selectSpotByNoNonExistent() {
+    @DisplayName("존재하지 않는 관광지 번호로 기본 정보 조회 테스트")
+    void selectBasicSpotByNoNonExistent() {
         // given
-        int nonExistentNo = 0; // 존재하지 않는 번호
+        int nonExistentNo = -1; // 존재하지 않는 번호
         
         // when
-        SpotDto spot = spotDao.selectSpotByNo(nonExistentNo);
+        BasicSpotResponseDto spot = spotDao.selectBasicSpotByNo(nonExistentNo);
         
         // then
         assertThat(spot).isNull();
     }
     
     @Test
-    @DisplayName("관광지 삭제 테스트")
-    void deleteSpot() {
-        // given - 새 관광지 생성
-        SpotDto newSpot = new SpotDto();
-        newSpot.setTitle("테스트 관광지");
-        newSpot.setContentTypeId(12);
-        newSpot.setAreaCode(11);
-        newSpot.setSiGunGuCode(110);
-        newSpot.setFirstImage1("http://example.com/image1.jpg");
-        newSpot.setLatitude(37.551254); // BigDecimal에서 double로 변경
-        newSpot.setLongitude(126.988444); // BigDecimal에서 double로 변경
-        newSpot.setAddr("서울특별시 중구 세종대로 110"); // addr1, addr2 대신 addr 사용
-        
-        spotDao.insertSpot(newSpot);
+    @DisplayName("연령대별 평점 조회 테스트")
+    void selectAgeRatingsByNo() {
+        // given
+        int existingNo = 1; // 리뷰가 있는 관광지 번호라고 가정
         
         // when
-        int result = spotDao.deleteSpot(newSpot.getNo());
+        AgeRatingDto ageRatings = spotDao.selectAgeRatingsByNo(existingNo);
+        
+        // then
+        assertThat(ageRatings).isNotNull();
+        
+        // 모든 연령대 평점이 0 이상 5 이하여야 함
+        assertThat(ageRatings.getTwenties()).isBetween(0.0, 5.0);
+        assertThat(ageRatings.getThirties()).isBetween(0.0, 5.0);
+        assertThat(ageRatings.getForties()).isBetween(0.0, 5.0);
+        assertThat(ageRatings.getFifties()).isBetween(0.0, 5.0);
+        assertThat(ageRatings.getSixties()).isBetween(0.0, 5.0);
+    }
+    
+    @Test
+    @DisplayName("리뷰가 없는 관광지의 연령대별 평점 조회 테스트")
+    void selectAgeRatingsByNoWithoutReviews() {
+        // given
+        int spotWithoutReviews = 9999; // 리뷰가 없는 관광지 번호라고 가정
+        
+        // when
+        AgeRatingDto ageRatings = spotDao.selectAgeRatingsByNo(spotWithoutReviews);
+        
+        // then
+        assertThat(ageRatings).isNotNull();
+        
+        // 리뷰가 없으면 모든 연령대 평점이 0.0이어야 함
+        assertThat(ageRatings.getTwenties()).isEqualTo(0.0);
+        assertThat(ageRatings.getThirties()).isEqualTo(0.0);
+        assertThat(ageRatings.getForties()).isEqualTo(0.0);
+        assertThat(ageRatings.getFifties()).isEqualTo(0.0);
+        assertThat(ageRatings.getSixties()).isEqualTo(0.0);
+    }
+    
+    @Test
+    @DisplayName("가장 인기있는 동행타입 조회 테스트")
+    void selectMostPopularAccompanyTypeByNo() {
+        // given
+        int existingNo = 1; // 리뷰가 있는 관광지 번호라고 가정
+        
+        // when
+        String mostPopularAccompanyType = spotDao.selectMostPopularAccompanyTypeByNo(existingNo);
+        
+        // then
+        // 리뷰가 있다면 동행타입이 반환되어야 함 (null이 아님)
+        // 리뷰가 없거나 동행타입이 없다면 null일 수 있음
+        if (mostPopularAccompanyType != null) {
+            assertThat(mostPopularAccompanyType).isNotBlank();
+        }
+    }
+    
+    @Test
+    @DisplayName("가장 인기있는 모티브 조회 테스트")
+    void selectMostPopularMotiveByNo() {
+        // given
+        int existingNo = 1; // 리뷰가 있는 관광지 번호라고 가정
+        
+        // when
+        String mostPopularMotive = spotDao.selectMostPopularMotiveByNo(existingNo);
+        
+        // then
+        // 리뷰가 있고 모티브가 설정된 사용자가 있다면 모티브가 반환되어야 함
+        // 그렇지 않다면 null일 수 있음
+        if (mostPopularMotive != null) {
+            assertThat(mostPopularMotive).isNotBlank();
+        }
+    }
+    
+    @Test
+    @DisplayName("관광지 삭제 테스트")
+    void deleteSpot() {
+        // given
+        int existingNo = 1; // 존재하는 관광지 번호라고 가정
+        
+        // 삭제 전 존재 확인
+        BasicSpotResponseDto spotBeforeDelete = spotDao.selectBasicSpotByNo(existingNo);
+        assertThat(spotBeforeDelete).isNotNull();
+        
+        // when
+        int result = spotDao.deleteSpot(existingNo);
         
         // then
         assertThat(result).isEqualTo(1); // 1행이 삭제되었는지 확인
-        assertThat(spotDao.selectSpotByNo(newSpot.getNo())).isNull(); // 삭제 후 존재하지 않는지 확인
+        
+        // 삭제 후 존재하지 않는지 확인
+        BasicSpotResponseDto spotAfterDelete = spotDao.selectBasicSpotByNo(existingNo);
+        assertThat(spotAfterDelete).isNull();
     }
     
-    
     @Test
-    @DisplayName("관광지 등록 테스트")
-    void insertSpot() {
+    @DisplayName("존재하지 않는 관광지 삭제 테스트")
+    void deleteNonExistentSpot() {
         // given
-        SpotDto newSpot = new SpotDto();
-        newSpot.setTitle("테스트 관광지");
-        newSpot.setContentTypeId(12);
-        newSpot.setAreaCode(11);
-        newSpot.setSiGunGuCode(110);
-        newSpot.setFirstImage1("http://example.com/image1.jpg");
-        newSpot.setLatitude(37.551254); // BigDecimal에서 double로 변경
-        newSpot.setLongitude(126.988444); // BigDecimal에서 double로 변경
-        newSpot.setAddr("서울특별시 중구 세종대로 110"); // addr 추가
-        newSpot.setHomepage("http://example.com");
-        newSpot.setOverview("테스트 관광지 설명입니다.");
+        int nonExistentNo = -1; // 존재하지 않는 번호
         
         // when
-        int result = spotDao.insertSpot(newSpot);
+        int result = spotDao.deleteSpot(nonExistentNo);
         
         // then
-        assertThat(result).isEqualTo(1); // 1행이 영향을 받았는지 확인
-        
-        // 삽입된 관광지 조회
-        SpotDto insertedSpot = spotDao.selectSpotByNo(newSpot.getNo());
-        assertThat(insertedSpot).isNotNull();
-        assertThat(insertedSpot.getTitle()).isEqualTo("테스트 관광지");
-        assertThat(insertedSpot.getAddr()).isEqualTo("서울특별시 중구 세종대로 110");
+        assertThat(result).isEqualTo(0); // 삭제된 행이 없음
     }
     
     @Test
-    @DisplayName("범위 내 관광지 검색 테스트")
-    void findInBounds() {
+    @DisplayName("범위 내 관광지 기본 정보 검색 테스트")
+    void selectBasicSpotsInBoundary() {
         // given
         double swLat = 37.0;
         double swLng = 126.0;
@@ -122,17 +175,68 @@ public class SpotDaoTest {
         Integer type = 12; // 관광타입 (옵션)
         
         // when
-        List<SpotDto> spotsInBounds = spotDao.findInBounds(swLat, swLng, neLat, neLng, type);
+        List<BasicSpotResponseDto> spotsInBounds = spotDao.selectBasicSpotsInBoundary(swLat, swLng, neLat, neLng, type);
         
         // then
         assertThat(spotsInBounds).isNotNull();
+        
         // 범위 내 모든 관광지의 위치가 실제로 범위 내에 있는지 확인
         spotsInBounds.forEach(spot -> {
             assertThat(spot.getLatitude()).isBetween(swLat, neLat);
             assertThat(spot.getLongitude()).isBetween(swLng, neLng);
+            assertThat(spot.getAverageRating()).isBetween(0.0, 5.0);
+            assertThat(spot.getReviewCount()).isGreaterThanOrEqualTo(0);
+            
             if (type != null) {
                 assertThat(spot.getContentTypeId()).isEqualTo(type);
             }
         });
+        
+        // 결과가 300개를 넘지 않는지 확인 (LIMIT 300)
+        assertThat(spotsInBounds.size()).isLessThanOrEqualTo(300);
+    }
+    
+    @Test
+    @DisplayName("타입 필터 없이 범위 내 관광지 검색 테스트")
+    void selectBasicSpotsInBoundaryWithoutTypeFilter() {
+        // given
+        double swLat = 37.0;
+        double swLng = 126.0;
+        double neLat = 38.0;
+        double neLng = 127.0;
+        Integer type = null; // 타입 필터 없음
+        
+        // when
+        List<BasicSpotResponseDto> spotsInBounds = spotDao.selectBasicSpotsInBoundary(swLat, swLng, neLat, neLng, type);
+        
+        // then
+        assertThat(spotsInBounds).isNotNull();
+        
+        // 범위 내 모든 관광지의 위치가 실제로 범위 내에 있는지 확인
+        spotsInBounds.forEach(spot -> {
+            assertThat(spot.getLatitude()).isBetween(swLat, neLat);
+            assertThat(spot.getLongitude()).isBetween(swLng, neLng);
+            assertThat(spot.getAverageRating()).isBetween(0.0, 5.0);
+            assertThat(spot.getReviewCount()).isGreaterThanOrEqualTo(0);
+            // 타입 필터가 없으므로 모든 타입이 포함될 수 있음
+        });
+    }
+    
+    @Test
+    @DisplayName("빈 범위에서 관광지 검색 테스트")
+    void selectBasicSpotsInBoundaryEmptyRange() {
+        // given - 관광지가 없을 것 같은 범위
+        double swLat = 90.0;  // 북극 근처
+        double swLng = 180.0;
+        double neLat = 90.1;
+        double neLng = 180.1;
+        Integer type = null;
+        
+        // when
+        List<BasicSpotResponseDto> spotsInBounds = spotDao.selectBasicSpotsInBoundary(swLat, swLng, neLat, neLng, type);
+        
+        // then
+        assertThat(spotsInBounds).isNotNull();
+        assertThat(spotsInBounds).isEmpty(); // 빈 결과가 예상됨
     }
 }


### PR DESCRIPTION
관광지를 조회할 때 좀 더 세부적인 정보를 받아오기 위해
spot dto를 기본과 상세 spot으로 나누고 이에 따라 메서드를 수정하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 장소(Spot)에 대한 기본 정보와 상세 정보를 구분하여 조회할 수 있는 기능이 추가되었습니다. 기본 정보에는 평균 평점과 리뷰 수가 포함되며, 상세 정보에는 연령대별 평점, 인기 동행 유형, 인기 방문 동기가 포함됩니다.

- **개선 사항**
  - 장소 목록 및 개별 조회, 삭제, 경계 내 검색 시 반환 정보가 더 구체적이고 요약된 형태로 변경되었습니다.
  - API 문서화(Javadoc)가 개선되어 파라미터와 반환값 설명이 추가되었습니다.

- **버그 수정**
  - 존재하지 않는 장소 조회 및 삭제 시 적절한 예외 처리가 적용되었습니다.

- **테스트**
  - 새로운 DTO와 기능에 맞춘 테스트가 추가 및 개선되었습니다. 연령대 평점, 인기 동행 유형/방문 동기, 경계 내 검색 등 다양한 케이스가 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->